### PR TITLE
Add calculus solver

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,17 @@
 # mathematical-analysis-
-This is a mathematical analysis 
+
+This repository provides a simple calculus solver. The solver can evaluate
+LaTeX expressions representing derivatives, integrals and summations.
+
+## Usage
+
+Run the solver from the command line and pass a LaTeX expression in quotes.
+Examples:
+
+```bash
+python calculus_solver.py "\\frac{d}{dx} x^2"
+python calculus_solver.py "\\int x^2 dx"
+python calculus_solver.py "\\sum_{n=1}^5 n^2"
+```
+
+The script prints a few steps and the final result in LaTeX format.

--- a/calculus_solver.py
+++ b/calculus_solver.py
@@ -1,0 +1,47 @@
+import sys
+import sympy as sp
+from sympy.parsing.latex import parse_latex
+
+
+def parse_expression(expr_str: str):
+    try:
+        return parse_latex(expr_str)
+    except Exception:
+        return sp.sympify(expr_str)
+
+
+def solve_expression(expr: sp.Expr) -> str:
+    if isinstance(expr, sp.Integral):
+        result = sp.integrate(expr.function, *expr.limits)
+        latex_expr = sp.latex(expr)
+        latex_result = sp.latex(result)
+        steps = [f"Given integral $${latex_expr}$$", f"Evaluating the integral:", f"$$ {latex_result} $$ + C"]
+        return "\n".join(steps)
+    elif isinstance(expr, sp.Derivative):
+        result = expr.doit()
+        latex_expr = sp.latex(expr)
+        latex_result = sp.latex(result)
+        steps = [f"Given derivative $${latex_expr}$$", f"Computing the derivative:", f"$$ {latex_result} $$"]
+        return "\n".join(steps)
+    elif isinstance(expr, sp.Sum):
+        result = expr.doit()
+        latex_expr = sp.latex(expr)
+        latex_result = sp.latex(result)
+        steps = [f"Given sum $${latex_expr}$$", f"Evaluating the sum:", f"$$ {latex_result} $$"]
+        return "\n".join(steps)
+    else:
+        raise ValueError("Unsupported expression type")
+
+
+def main():
+    if len(sys.argv) < 2:
+        print('Usage: python calculus_solver.py "<latex expression>"')
+        return
+    expr_str = sys.argv[1]
+    expr = parse_expression(expr_str)
+    solution = solve_expression(expr)
+    print(solution)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_solver.py
+++ b/tests/test_solver.py
@@ -1,0 +1,24 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+from calculus_solver import parse_expression, solve_expression
+
+
+def test_derivative():
+    expr = parse_expression("\\frac{d}{dx} x^2")
+    result = solve_expression(expr)
+    assert "2 x" in result
+
+
+def test_integral():
+    expr = parse_expression("\\int x dx")
+    result = solve_expression(expr)
+    assert "\\frac{x^{2}}{2}" in result
+
+
+def test_sum():
+    expr = parse_expression("\\sum_{n=1}^3 n")
+    result = solve_expression(expr)
+    assert "6" in result


### PR DESCRIPTION
## Summary
- add a small calculus solver that handles derivatives, integrals, and sums
- document how to use the solver
- add tests for solver functionality

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840301f0b3c832eb5c720a7dfbda435